### PR TITLE
update to be compatible with newer versions of react-native (>0.47)

### DIFF
--- a/android/src/main/java/dk/madslee/mobilepay/RNMobilePayPackage.java
+++ b/android/src/main/java/dk/madslee/mobilepay/RNMobilePayPackage.java
@@ -20,7 +20,6 @@ public class RNMobilePayPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
React Native 0.47 has removed the createJSModules method in ReactPackage.
Therefore any overrides of this method will need to be removed from the library, or this will cause a compilation error.